### PR TITLE
 Added the import of serial_link &  Removed the matrix type check of T matrix in ikine function

### DIFF
--- a/robopy/base/__init__.py
+++ b/robopy/base/__init__.py
@@ -3,3 +3,4 @@ from robopy.base.model import *
 from robopy.base.quaternion import *
 from robopy.base.pose import *
 from robopy.base.util import *
+from robopy.base.serial_link import *

--- a/robopy/base/serial_link.py
+++ b/robopy/base/serial_link.py
@@ -114,7 +114,7 @@ class SerialLink:
         :param unit: preferred unit for returned joint angles. Allowed values: 'rad' or 'deg'.
         :return: a list of 6 joint angles.
         """
-        assert type(T) is np.matrix and T.shape == (4, 4)
+        assert T.shape == (4, 4)
         bounds = [(link.qlim[0], link.qlim[1]) for link in self]
         reach = 0
         for link in self:


### PR DESCRIPTION
1. Added the import of 'serial_link' at '__init__.py', which can make the 'Prismatic' class can be load by users

2. Removed the matrix type check of T matrix in 'ikine' function. Does not work in my test, the matrix type with numpy is 'numpy.matrixlib.defmatrix.matrix' instead of 'numpy.matrix'.